### PR TITLE
Allow to use patched numpy (e.g. np.concatenate/quantities)

### DIFF
--- a/examples/_convert_to_autonomous_eyring_sinusoidal.ipynb
+++ b/examples/_convert_to_autonomous_eyring_sinusoidal.ipynb
@@ -248,7 +248,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/pyodesys/core.py
+++ b/pyodesys/core.py
@@ -190,7 +190,7 @@ class ODESys(object):
             raise ValueError("Unknown kwargs: %s" % str(kwargs))
 
     @staticmethod
-    def _array_from_dict(d, keys):
+    def _array_from_dict(d, keys, numpy=np):
         vals = [d[k] for k in keys]
         lens = [len(v) for v in vals if hasattr(v, '__len__') and getattr(v, 'ndim', 1) > 0]
         if len(lens) == 0:
@@ -198,7 +198,7 @@ class ODESys(object):
         else:
             if not all(l == lens[0] for l in lens):
                 raise ValueError("Mixed lenghts in dictionary.")
-            out = self.numpy.empty((lens[0], len(vals)), dtype=object)
+            out = numpy.empty((lens[0], len(vals)), dtype=object)
             for idx, v in enumerate(vals):
                 if getattr(v, 'ndim', -1) == 0:
                     for j in range(lens[0]):
@@ -215,7 +215,7 @@ class ODESys(object):
         if isinstance(cont, dict):
             if not by_name:
                 raise ValueError("not by name, yet a dictionary was passed.")
-            cont, tp = self._array_from_dict(cont, names)
+            cont, tp = self._array_from_dict(cont, names, numpy=self.numpy)
         else:
             tp = False
         return cont, tp

--- a/pyodesys/results.py
+++ b/pyodesys/results.py
@@ -247,23 +247,25 @@ class Result(object):
         x0 = self.xout[-1]
         nx0 = self.xout.size
         res = odesys.integrate(
-            np.linspace(0, (xend - x0), npoints+1) if autonomous else np.linspace(x0, xend, npoints+1),
-            self.yout[..., -1, :], params or self.params, **kwargs
+            (
+                self.odesys.numpy.linspace((xend - x0)*0, (xend - x0), npoints+1) if autonomous
+                else self.odesys.numpy.linspace(x0, xend, npoints+1)
+            ), self.yout[..., -1, :], params or self.params, **kwargs
         )
-        self.xout = np.concatenate((self.xout, res.xout[1:] + (x0 if autonomous else 0)))
-        self.yout = np.concatenate((self.yout, res.yout[..., 1:, :]))
+        self.xout = self.odesys.numpy.concatenate((self.xout, res.xout[1:] + (x0 if autonomous else 0)))
+        self.yout = self.odesys.numpy.concatenate((self.yout, res.yout[..., 1:, :]))
         new_info = {k: v for k, v in self.info.items() if not (
             k.startswith('internal') and odesys is not self.odesys)}
         for k, v in res.info.items():
             if k.startswith('internal'):
                 if odesys is self.odesys:
-                    new_info[k] = np.concatenate((new_info[k], v))
+                    new_info[k] = self.odesys.numpy.concatenate((new_info[k], v))
                 else:
                     continue
             elif k == 'success':
                 new_info[k] = new_info[k] and v
             elif k.endswith('_xvals'):
-                new_info[k] = np.concatenate((new_info[k], v + (x0 if autonomous else 0)))
+                new_info[k] = self.odesys.numpy.concatenate((new_info[k], v + (x0 if autonomous else 0)))
             elif k.endswith('_indices'):
                 new_info[k].extend([itm + nx0 - 1 for itm in v])
             elif isinstance(v, str):

--- a/pyodesys/symbolic.py
+++ b/pyodesys/symbolic.py
@@ -203,7 +203,7 @@ class SymbolicSys(ODESys):
                       'linear_invariants', 'linear_invariant_names',
                       'nonlinear_invariants', 'nonlinear_invariant_names',
                       'to_arrays_callbacks', '_indep_autonomous_key',
-                      'taken_names')
+                      'taken_names', 'numpy')
     append_iv = True
 
     @property


### PR DESCRIPTION
`numpy.linspace` and `numpy.concatenate` discards units when using ``quantities``. This allows the user to supply a patched module imitating ``numpy``.