### PR TITLE
Update to new pycvodes

### DIFF
--- a/pyodesys/native/cvode.py
+++ b/pyodesys/native/cvode.py
@@ -25,7 +25,7 @@ class NativeCvodeCode(_NativeCodeBase):
         self.compile_kwargs['include_dirs'].append(get_include())
         self.compile_kwargs['libraries'].extend(_config.env['SUNDIALS_LIBS'].split(','))
         self.compile_kwargs['libraries'].extend(os.environ.get(
-            'PYODESYS_LAPACK', _config.env['LAPACK']).split(','))
+            'PYODESYS_LAPACK', [l for l in _config.env['LAPACK'].split(',') if l not in ('', '0')]))
         super(NativeCvodeCode, self).__init__(*args, **kwargs)
 
 

--- a/pyodesys/native/sources/anyode/anyode.hpp
+++ b/pyodesys/native/sources/anyode/anyode.hpp
@@ -1,11 +1,24 @@
 #ifdef ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37
 
-#if ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 != 14
+#if ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 != 16
 #error "Multiple anyode.hpp files included with version mismatch"
 #endif
 
 #else
-#define ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 14
+#define ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 16
+
+#ifndef ANYODE_RESTRICT
+  #if defined(__GNUC__)
+    #define ANYODE_RESTRICT __restrict__
+  #elif defined(_MSC_VER) && _MSC_VER >= 1400
+    #define ANYODE_RESTRICT __restrict
+  #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+    #define ANYODE_RESTRICT restrict
+  #else
+    #define ANYODE_RESTRICT
+  #endif
+#endif
+
 
 #include <memory>
 #include <cstdlib>
@@ -66,7 +79,7 @@ struct Info {
         for (const auto &kv : DICT_OF_VECTORS){     \
             const auto &k = kv.first;               \
             const auto &v = kv.second;              \
-            out << k << ": [";                      \
+            out << k << joiner << "[";              \
             for (auto it=v.begin();it != v.end();){ \
                 out << *it;                         \
                 ++it;                               \
@@ -76,7 +89,7 @@ struct Info {
                     out << delimiter;               \
                 }                                   \
             }                                       \
-            out << "]" << joiner;                   \
+            out << "]" << delimiter;                \
         }
         ANYODE_PRINT(nfo_vecdbl);
         ANYODE_PRINT(nfo_vecint);
@@ -155,37 +168,37 @@ struct OdeSysBase {
         return Status::unrecoverable_error;
     }
     virtual Status dense_jac_cmaj(Real_t t,
-                                  const Real_t * const __restrict__ y,
-                                  const Real_t * const __restrict__ fy,
-                                  Real_t * const __restrict__ jac,
+                                  const Real_t * const ANYODE_RESTRICT y,
+                                  const Real_t * const ANYODE_RESTRICT fy,
+                                  Real_t * const ANYODE_RESTRICT jac,
                                   long int ldim,
-                                  Real_t * const __restrict__ dfdt=nullptr){
+                                  Real_t * const ANYODE_RESTRICT dfdt=nullptr){
         ignore(t); ignore(y); ignore(fy); ignore(jac); ignore(ldim); ignore(dfdt);
         return Status::unrecoverable_error;
     }
     virtual Status dense_jac_rmaj(Real_t t,
-                                  const Real_t * const __restrict__ y,
-                                  const Real_t * const __restrict__ fy,
-                                  Real_t * const __restrict__ jac,
+                                  const Real_t * const ANYODE_RESTRICT y,
+                                  const Real_t * const ANYODE_RESTRICT fy,
+                                  Real_t * const ANYODE_RESTRICT jac,
                                   long int ldim,
-                                  Real_t * const __restrict__ dfdt=nullptr){
+                                  Real_t * const ANYODE_RESTRICT dfdt=nullptr){
         ignore(t); ignore(y); ignore(fy); ignore(jac); ignore(ldim); ignore(dfdt);
         return Status::unrecoverable_error;
     }
     virtual Status banded_jac_cmaj(Real_t t,
-                                   const Real_t * const __restrict__ y,
-                                   const Real_t * const __restrict__ fy,
-                                   Real_t * const __restrict__ jac,
+                                   const Real_t * const ANYODE_RESTRICT y,
+                                   const Real_t * const ANYODE_RESTRICT fy,
+                                   Real_t * const ANYODE_RESTRICT jac,
                                    long int ldim){
         ignore(t); ignore(y); ignore(fy); ignore(jac); ignore(ldim);
         throw std::runtime_error("banded_jac_cmaj not implemented.");
         return Status::unrecoverable_error;
     }
-    virtual Status jac_times_vec(const Real_t * const __restrict__ vec,
-                                 Real_t * const __restrict__ out,
+    virtual Status jac_times_vec(const Real_t * const ANYODE_RESTRICT vec,
+                                 Real_t * const ANYODE_RESTRICT out,
                                  Real_t t,
-                                 const Real_t * const __restrict__ y,
-                                 const Real_t * const __restrict__ fy
+                                 const Real_t * const ANYODE_RESTRICT y,
+                                 const Real_t * const ANYODE_RESTRICT fy
                                  )
     {
         ignore(vec);
@@ -196,8 +209,8 @@ struct OdeSysBase {
         return Status::unrecoverable_error;
     }
     virtual Status prec_setup(Real_t t,
-                            const Real_t * const __restrict__ y,
-                            const Real_t * const __restrict__ fy,
+                            const Real_t * const ANYODE_RESTRICT y,
+                            const Real_t * const ANYODE_RESTRICT fy,
                             bool jok,
                             bool& jac_recomputed,
                             Real_t gamma)
@@ -211,13 +224,13 @@ struct OdeSysBase {
         return Status::unrecoverable_error;
     }
     virtual Status prec_solve_left(const Real_t t,
-                                   const Real_t * const __restrict__ y,
-                                   const Real_t * const __restrict__ fy,
-                                   const Real_t * const __restrict__ r,
-                                   Real_t * const __restrict__ z,
+                                   const Real_t * const ANYODE_RESTRICT y,
+                                   const Real_t * const ANYODE_RESTRICT fy,
+                                   const Real_t * const ANYODE_RESTRICT r,
+                                   Real_t * const ANYODE_RESTRICT z,
                                    Real_t gamma,
                                    Real_t delta,
-                                   const Real_t * const __restrict__ ewt)
+                                   const Real_t * const ANYODE_RESTRICT ewt)
     {
         ignore(t);
         ignore(y);

--- a/pyodesys/native/sources/anyode/anyode_buffer.hpp
+++ b/pyodesys/native/sources/anyode/anyode_buffer.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#ifdef NDEBUG
 #include<memory>
-#else
+
+#ifndef NDEBUG
 #include<vector>
+#include<limits>
 #endif
 
 namespace AnyODE {
@@ -34,6 +35,7 @@ namespace AnyODE {
         return std::unique_ptr<T>(new RT[n]);
     }
 #endif
+
 #ifdef NDEBUG
     template<typename T> using buffer_t = std::unique_ptr<T[]>;
     template<typename T> using buffer_ptr_t = T*;
@@ -43,15 +45,21 @@ namespace AnyODE {
     template<typename T> inline constexpr buffer_t<T> buffer_factory(std::size_t n) {
         return make_unique<T[]>(n);
     }
+    template<typename T> constexpr bool buffer_is_initialized(const buffer_t<T>& buf) {
+        return (bool)buf;
+    }
 
 #else
     template<typename T> using buffer_t = std::vector<T>;
     template<typename T> using buffer_ptr_t = T*;
     template<typename T> inline constexpr buffer_t<T> buffer_factory(std::size_t n) {
-        return buffer_t<T>(n);
+        return buffer_t<T>(n, std::numeric_limits<T>::signaling_NaN());
     }
     template<typename T> constexpr T* buffer_get_raw_ptr(buffer_t<T>& buf) {
         return &buf[0];
+    }
+    template<typename T> constexpr bool buffer_is_initialized(const buffer_t<T>& buf) {
+        return buf.size() > 0;
     }
 #endif
 }

--- a/pyodesys/native/sources/anyode/anyode_iterative.hpp
+++ b/pyodesys/native/sources/anyode/anyode_iterative.hpp
@@ -17,11 +17,11 @@ namespace AnyODE {
         std::unique_ptr<JacMat_t> m_M_cache {nullptr};
         std::unique_ptr<Decomp_t> m_decomp_cache {nullptr};
 
-        virtual Status jac_times_vec(const Real_t * const __restrict__ vec,
-                                     Real_t * const __restrict__ out,
+        virtual Status jac_times_vec(const Real_t * const ANYODE_RESTRICT vec,
+                                     Real_t * const ANYODE_RESTRICT out,
                                      Real_t t,
-                                     const Real_t * const __restrict__ y,
-                                     const Real_t * const __restrict__ fy
+                                     const Real_t * const ANYODE_RESTRICT y,
+                                     const Real_t * const ANYODE_RESTRICT fy
                                      ) override
         {
             // See "Jacobian information (matrix-vector product)"
@@ -37,8 +37,8 @@ namespace AnyODE {
         }
 
         virtual Status prec_setup(Real_t t,
-                                  const Real_t * const __restrict__ y,
-                                  const Real_t * const __restrict__ fy,
+                                  const Real_t * const ANYODE_RESTRICT y,
+                                  const Real_t * const ANYODE_RESTRICT fy,
                                   bool jac_ok,
                                   bool& jac_recomputed,
                                   Real_t gamma) override
@@ -66,13 +66,13 @@ namespace AnyODE {
         }
 
         virtual Status prec_solve_left(const Real_t t,
-                                       const Real_t * const __restrict__ y,
-                                       const Real_t * const __restrict__ fy,
-                                       const Real_t * const __restrict__ r,
-                                       Real_t * const __restrict__ z,
+                                       const Real_t * const ANYODE_RESTRICT y,
+                                       const Real_t * const ANYODE_RESTRICT fy,
+                                       const Real_t * const ANYODE_RESTRICT r,
+                                       Real_t * const ANYODE_RESTRICT z,
                                        Real_t /* gamma */,
                                        Real_t /* delta */,
-                                       const Real_t * const __restrict__ ewt
+                                       const Real_t * const ANYODE_RESTRICT ewt
                                        ) override
         {
             // See 4.6.9 on page 75 in cvs_guide.pdf (Sundials 2.6.2)


### PR DESCRIPTION
pycvodes-0.10.7 allows not linking with LAPACK (in which case the variable is `''` or `'0'`)