### PR TITLE
Specify upper limits for versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,8 +7,8 @@ build:
     - LIBRARY_PATH=/opt/boost_1_65_0/lib
     - LD_LIBRARY_PATH=/opt/boost_1_65_0/lib
   commands:
-    - python2 -m pip install --ignore-installed --no-deps quantities==0.12.1  # https://github.com/python-quantities/python-quantities/issues/122
-    - python3 -m pip install --ignore-installed --no-deps quantities==0.12.1
+    - python2 -m pip install --ignore-installed --no-deps quantities==0.12.2  # https://github.com/python-quantities/python-quantities/issues/122
+    - python3 -m pip install --ignore-installed --no-deps quantities==0.12.2
     - PYCVODES_LAPACK=lapack,blas ./scripts/ci.sh pyodesys
     - ./scripts/prepare_deploy.sh
     - rm -r ~/.cache/python*pyodesys*/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+v0.11.15
+========
+- Updated (upper) requirements of pycvodes, pygslodeiv2, pyodeint (v0.12.0 will again require latest versions)
+
 v0.11.14
 ========
 - Relax a few native tests

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,9 +27,9 @@ requirements:
     - matplotlib
     - appdirs
     - boost
-    - pyodeint >=0.9.4
-    - pygslodeiv2 >=0.8.4
-    - pycvodes >=0.10.5
+    - pyodeint <0.9.5
+    - pygslodeiv2 <0.9.0
+    - pycvodes <0.11.0
     - pycompilation
     - pycodeexport
     - python-symengine

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ if not len(long_descr) > 100:
 _author, _author_email = open(_path_under_setup('AUTHORS'), 'rt').readline().split('<')
 
 extras_req = {
-    'integrators': ['pyodeint>=0.9.4', 'pycvodes>=0.10.5', 'pygslodeiv2>=0.8.4'],
+    'integrators': ['pyodeint<=0.9.4', 'pycvodes<0.11.0', 'pygslodeiv2<=0.8.4'],
     'native': ['pycompilation>=0.4.3', 'pycodeexport>=0.1.1', 'appdirs'],
     'docs': ['Sphinx', 'sphinx_rtd_theme', 'numpydoc'],
     'testing': ['pytest-cov', 'pytest-flakes', 'pytest-pep8']


### PR DESCRIPTION
This will be a final patch release to the v0.11.x series where I will require versions of `pyodeint`, `pygslodeiv2` & `pycvodes` less than the latest released versions (with the new AnyODE interface)