### PR TITLE
Sparse jac

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - python
     - numpy
-    - sym >=0.3.3
+    - sym >=0.3.4
     - sympy >=1.1.1,!=1.2
     - scipy
     - matplotlib

--- a/examples/_sparse_matrix.ipynb
+++ b/examples/_sparse_matrix.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import sympy\n",
+    "from pyodesys.symbolic import SymbolicSys\n",
+    "from pyodesys.tests._robertson import get_ode_exprs\n",
+    "sympy.init_printing()\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logc, logt, reduced, powsimp = False, False, False, False\n",
+    "odesys1 = SymbolicSys.from_callback(get_ode_exprs(logc, logt, reduced)[0],\n",
+    "                                   2 if reduced else 3, 6 if reduced else 3)\n",
+    "odesys1.exprs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "odesys1._jac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Converting to sparse representation of jacobian:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sparse = SymbolicSys.from_other(odesys1, sparse=True)\n",
+    "sparse.nnz, sparse._rowvals, sparse._colptrs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sparse._jac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Converting back to dense representation of jacobian:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "odesys2 = SymbolicSys.from_other(sparse, sparse=False)\n",
+    "assert odesys2.nnz == -1\n",
+    "odesys2._jac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Solving the initial value problem numerically:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def solve_and_plot(odesys, integrate_kw, tout=[0, 1e11], y0=[1,0,0],\n",
+    "                   params=[0.04, 1e4, 3e7], ax=None):\n",
+    "    result = odesys.integrate(tout, y0, params, nsteps=5000,\n",
+    "                              integrator='cvode', **integrate_kw)\n",
+    "    result.plot(ax=ax, title_info=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pycvodes\n",
+    "has_klu = pycvodes.config['NO_KLU'] == '0'\n",
+    "systems = [odesys1, sparse, odesys2]\n",
+    "kws = [{}, dict(linear_solver='klu'), {}]\n",
+    "fig, axes = plt.subplots(1, len(systems), figsize=(5*len(systems), 4),\n",
+    "                         subplot_kw=dict(xscale='log', yscale='log'))\n",
+    "for odesys, ax, kw in zip(systems, axes, kws):\n",
+    "    if kw.get('linear_solver', '') == 'klu' and not has_klu:\n",
+    "        continue\n",
+    "    solve_and_plot(odesys, kw, ax=ax)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyodesys/core.py
+++ b/pyodesys/core.py
@@ -52,10 +52,11 @@ class ODESys(object):
     jac : callback
         Jacobian matrix (dfdy). Required for implicit methods.
         Signature should be either of:
-            - ``jac(x, y[:])``
-            - ``jac(x, y[:], p[:])``.
-        Should return a 2D array J[:,:] for dense/banded jacobians or
-        an instance of ``scipy.sparse.csc_matrix`` if ``sparse=True``.
+            - ``jac(x, y[:]) -> J``
+            - ``jac(x, y[:], p[:]) -J``.
+        If ``nnz < 0``, ``J`` should be a 2D array-like object if ``nnz < 0``
+        corresponding to a dense or banded jacobian (see also ``band``).
+        If ``nnz >= 0``, ``J`` should be an instance of ``scipy.sparse.csc_matrix``.
     dfdx : callback
         Signature ``dfdx(x, y[:], p[:]) -> out[:]`` (used by e.g. GSL)
     jtimes : callback
@@ -107,8 +108,7 @@ class ODESys(object):
         independent variable during integration.
     nnz : int (default : -1)
         Maximum number of non-zero entries in sparse jacobian. When
-        non-negative, indicates that ``jac`` returns a ``scipy.sparse`` matrix
-        instance. When negative, ``jac`` should return a dense/banded matrix.
+        non-negative, jacobian is assumed to be dense or banded.
 
     Attributes
     ----------

--- a/pyodesys/core.py
+++ b/pyodesys/core.py
@@ -48,9 +48,14 @@ class ODESys(object):
         dependent variable (x). Signature is any of:
             - ``rhs(x, y[:]) -> f[:]``
             - ``rhs(x, y[:], p[:]) -> f[:]``
-            - ``rhs(x, y[:], p[:], backend=math) -> f[:]``
+            - ``rhs(x, y[:], p[:], backend=math) -> f[:]``.
     jac : callback
         Jacobian matrix (dfdy). Required for implicit methods.
+        Signature should be either of:
+            - ``jac(x, y[:])``
+            - ``jac(x, y[:], p[:])``.
+        Should return a 2D array J[:,:] for dense/banded jacobians or
+        an instance of ``scipy.sparse.csc_matrix`` if ``sparse=True``.
     dfdx : callback
         Signature ``dfdx(x, y[:], p[:]) -> out[:]`` (used by e.g. GSL)
     jtimes : callback
@@ -100,6 +105,10 @@ class ODESys(object):
         Describes whether the independent variable appears in the rhs expressions.
         If set to ``True`` the underlying solver is allowed to shift the
         independent variable during integration.
+    nnz : int (default : -1)
+        Maximum number of non-zero entries in sparse jacobian. When
+        non-negative, indicates that ``jac`` returns a ``scipy.sparse`` matrix
+        instance. When negative, ``jac`` should return a dense/banded matrix.
 
     Attributes
     ----------
@@ -115,6 +124,7 @@ class ODESys(object):
         For calculating the first step based on x0, y0 & p.
     roots_cb : callback
     nroots : int
+    nnz : int
     names : tuple of strings
     param_names : tuple of strings
     description : str
@@ -151,7 +161,7 @@ class ODESys(object):
                  par_by_name=False, latex_names=(), latex_param_names=(), latex_indep_name=None,
                  taken_names=None, pre_processors=None, post_processors=None, append_iv=False,
                  autonomous_interface=None, to_arrays_callbacks=None, autonomous_exprs=None,
-                 _indep_autonomous_key=None, numpy=None, **kwargs):
+                 _indep_autonomous_key=None, numpy=None, nnz=-1, **kwargs):
         self.f_cb = _ensure_4args(f)
         self.j_cb = _ensure_4args(jac) if jac is not None else None
         self.jtimes_cb = _ensure_4args(jtimes) if jtimes is not None else None
@@ -163,6 +173,7 @@ class ODESys(object):
             if not band[0] >= 0 or not band[1] >= 0:
                 raise ValueError("bands needs to be > 0 if provided")
         self.band = band
+        self.nnz = nnz
         self.names = tuple(names or ())
         self.param_names = tuple(param_names or ())
         self.indep_name = indep_name
@@ -577,16 +588,29 @@ class ODESys(object):
             if with_jacobian is None:
                 raise Exception("Must pass with_jacobian")
             elif with_jacobian is True:
-                def _j(x, y, jout, dfdx_out=None, fy=None):
-                    if len(_p) > 0:
-                        jout[:, :] = np.asarray(self.j_cb(x, y, _p))
-                    else:
-                        jout[:, :] = np.asarray(self.j_cb(x, y))
-                    if dfdx_out is not None:
+                if self.nnz >= 0:
+                    def _j(x, y, data, colptrs, rowvals):
                         if len(_p) > 0:
-                            dfdx_out[:] = np.asarray(self.dfdx_cb(x, y, _p))
+                            J = self.j_cb(x, y, _p)
                         else:
-                            dfdx_out[:] = np.asarray(self.dfdx_cb(x, y))
+                            J = self.j_cb(x, y)
+                        J = J.asformat("csc")
+                        data[:] = J.data
+                        colptrs[:] = J.indptr
+                        rowvals[:] = J.indices
+
+                    new_kwargs['nnz'] = self.nnz
+                else:
+                    def _j(x, y, jout, dfdx_out=None, fy=None):
+                        if len(_p) > 0:
+                            jout[:, :] = np.asarray(self.j_cb(x, y, _p))
+                        else:
+                            jout[:, :] = np.asarray(self.j_cb(x, y))
+                        if dfdx_out is not None:
+                            if len(_p) > 0:
+                                dfdx_out[:] = np.asarray(self.dfdx_cb(x, y, _p))
+                            else:
+                                dfdx_out[:] = np.asarray(self.dfdx_cb(x, y))
             else:
                 _j = None
 

--- a/pyodesys/native/_base.py
+++ b/pyodesys/native/_base.py
@@ -125,9 +125,14 @@ class _NativeCodeBase(Cpp_Code):
         all_invar = tuple(self.odesys.all_invariants())
         ninvar = len(all_invar)
         jac = self.odesys.get_jac()
+        nnz = self.odesys.nnz
         all_exprs = self.odesys.exprs + all_invar
-        if jac is not False:
+        if jac is not False and nnz < 0:
             jac_dfdx = list(reduce(add, jac.tolist() + self.odesys.get_dfdx().tolist()))
+            all_exprs += tuple(jac_dfdx)
+            nj = len(jac_dfdx)
+        elif jac is not False and nnz >= 0:
+            jac_dfdx = list(reduce(add, jac.tolist()))
             all_exprs += tuple(jac_dfdx)
             nj = len(jac_dfdx)
         else:
@@ -235,9 +240,10 @@ class _NativeCodeBase(Cpp_Code):
             },
             p_jac=None if jac is False else {
                 'cses': [(symb.name, _ccode(expr)) for symb, expr in jac_cses],
-                'exprs': {(idx//ny, idx % ny): _ccode(expr)
-                          for idx, expr in enumerate(jac_exprs[:ny*ny])},
-                'dfdt_exprs': list(map(_ccode, jac_exprs[ny*ny:]))
+                'exprs': list(map(_ccode, jac_exprs[:nj])),
+                'dfdt_exprs': list(map(_ccode, jac_exprs[nj:])),
+                'colptrs': None if nnz < 0 else self.odesys._colptrs,
+                'rowvals': None if nnz < 0 else self.odesys._rowvals
             },
             p_first_step=None if first_step is None else {
                 'cses': first_step_cses,

--- a/pyodesys/native/_base.py
+++ b/pyodesys/native/_base.py
@@ -238,12 +238,17 @@ class _NativeCodeBase(Cpp_Code):
                 'cses': [(symb.name, _ccode(expr)) for symb, expr in jtimes_cses],
                 'exprs': list(map(_ccode, jtimes_exprs))
             },
-            p_jac=None if jac is False else {
+            p_jac_dense=None if jac is False or nnz >= 0 else {
+                'cses': [(symb.name, _ccode(expr)) for symb, expr in jac_cses],
+                'exprs': {(idx//ny, idx % ny): _ccode(expr)
+                          for idx, expr in enumerate(jac_exprs[:ny*ny])},
+                'dfdt_exprs': list(map(_ccode, jac_exprs[ny*ny:]))
+            },
+            p_jac_sparse=None if jac is False or nnz < 0 else {
                 'cses': [(symb.name, _ccode(expr)) for symb, expr in jac_cses],
                 'exprs': list(map(_ccode, jac_exprs[:nj])),
-                'dfdt_exprs': list(map(_ccode, jac_exprs[nj:])),
-                'colptrs': None if nnz < 0 else self.odesys._colptrs,
-                'rowvals': None if nnz < 0 else self.odesys._rowvals
+                'colptrs': self.odesys._colptrs,
+                'rowvals': self.odesys._rowvals
             },
             p_first_step=None if first_step is None else {
                 'cses': first_step_cses,

--- a/pyodesys/native/sources/odesys_anyode_iterative.hpp
+++ b/pyodesys/native/sources/odesys_anyode_iterative.hpp
@@ -19,6 +19,7 @@ namespace odesys_anyode {
                bool, Real_t, std::vector<Real_t>);
         int nrev=0;  // number of calls to roots
         Index_t get_ny() const override;
+        Index_t get_nnz() const override;
         int get_nquads() const override;
         int get_nroots() const override;
         Real_t get_dx0(Real_t, const Real_t * const) override;
@@ -39,6 +40,12 @@ namespace odesys_anyode {
                                       Real_t * const __restrict__ jac,
                                       long int ldim,
                                       Real_t * const __restrict__ dfdt=nullptr) override;
+        AnyODE::Status sparse_jac_csc(Real_t t,
+                                      const Real_t * const __restrict__ y,
+                                      const Real_t * const __restrict__ fy,
+                                      Real_t * const __restrict__ data,
+                                      Index_t * const __restrict__ colptrs,
+                                      Index_t * const __restrict__ rowvals) override;
         AnyODE::Status jtimes(const Real_t * const __restrict__ vec,
                               Real_t * const __restrict__ out,
                               Real_t t,

--- a/pyodesys/native/sources/odesys_anyode_template.cpp
+++ b/pyodesys/native/sources/odesys_anyode_template.cpp
@@ -325,8 +325,8 @@ namespace odesys_anyode {
         this->njev++;
         return AnyODE::Status::success;
     %else:
-        AnyODE::ignore(x); AnyODE::ignore(y); AnyODE::ignore(data);
-        AnyODE::ignore(colptrs); AnyODE::ignore(rowvals);
+        AnyODE::ignore(x); AnyODE::ignore(y); AnyODE::ignore(fy);
+         AnyODE::ignore(data); AnyODE::ignore(colptrs); AnyODE::ignore(rowvals);
         return AnyODE::Status::unrecoverable_error;
     %endif
     }

--- a/pyodesys/native/tests/test_cvode.py
+++ b/pyodesys/native/tests/test_cvode.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function)
 import numpy as np
 import pytest
 
-from pyodesys.util import requires, pycvodes_double
+from pyodesys.util import requires, pycvodes_double, pycvodes_klu
 from pyodesys.symbolic import SymbolicSys, PartiallySolvedSystem
 
 from ._tests import (
@@ -236,6 +236,28 @@ def test_jtimes_native_cvode(nu=0.01, k=1.0, m=1.0, x0=1.0, atol=1.0e-12, rtol=1
     ref = a * np.exp(-nu * tout/2) * np.cos(w * tout - phi)
     assert info['njvev'] > 0
     assert info['njev'] == 0
+    assert np.allclose(yout[:, 0], ref)
+
+
+@pytest.mark.veryslow
+@requires('sym', 'pycvodes')
+@pycvodes_klu
+def test_sparse_jac_native_cvode(nu=0.01, k=1.0, m=1.0, x0=1.0, atol=1.0e-12, rtol=1.0e-12):
+    # Damped harmonic oscillator
+    w0 = (k/m)**0.5
+
+    def f(t, y, p):
+        return [y[1], -w0**2 * y[0] - nu * y[1]]
+
+    odesys = NativeSys.from_callback(f, 2, 0, jac=True, sparse=True)
+    tout, yout, info = odesys.integrate(100, [x0, 0], integrator='cvode', linear_solver='klu',
+                                        with_jacobian=True, atol=atol, rtol=rtol, nsteps=20000)
+
+    w = (w0**2 - nu**2/4.0)**0.5
+    a = (x0**2 + (nu * x0/2)**2/w**2)**0.5
+    phi = np.arctan(nu * x0 / (2 * x0 * w))
+    ref = a * np.exp(-nu * tout/2) * np.cos(w * tout - phi)
+    assert info['njev'] > 0
     assert np.allclose(yout[:, 0], ref)
 
 

--- a/pyodesys/symbolic.py
+++ b/pyodesys/symbolic.py
@@ -177,6 +177,10 @@ class SymbolicSys(ODESys):
         When ``True`` construct using ``be.Symbol``. See also :attr:`init_indep`.
     init_dep : tuple of Symbols, ``True`` or ``None``
         When ``True`` construct using ``be.Symbol``. See also :attr:`init_dep`.
+    sparse : bool (default ``False``)
+        When ``True``, jacobian will be derived and stored (if ``jac = True``)
+        in compressed sparse column (CSC) format and the jacobian callback
+        will return an instance of ``scipy.sparse.csc_matrix``.
     \*\*kwargs:
         See :py:class:`ODESys`
 

--- a/pyodesys/symbolic.py
+++ b/pyodesys/symbolic.py
@@ -228,7 +228,7 @@ class SymbolicSys(ODESys):
                  jtimes=False, first_step_expr=None, roots=None, backend=None, lower_bounds=None,
                  upper_bounds=None, linear_invariants=None, nonlinear_invariants=None,
                  linear_invariant_names=None, nonlinear_invariant_names=None, steady_state_root=False,
-                 init_indep=None, init_dep=None, **kwargs):
+                 init_indep=None, init_dep=None, sparse=False, **kwargs):
         self.dep, self.exprs = zip(*dep_exprs.items()) if isinstance(dep_exprs, dict) else zip(*dep_exprs)
         self.indep = indep
         if params is True or params is None:
@@ -278,6 +278,7 @@ class SymbolicSys(ODESys):
         if _param_names is True:
             kwargs['param_names'] = [p.name for p in self.params]
 
+        self.sparse = sparse # needed by get_j_ty_callback
         self.band = kwargs.get('band', None)  # needed by get_j_ty_callback
         # bounds needed by get_f_ty_callback:
         self.lower_bounds = None if lower_bounds is None else np.array(lower_bounds)*np.ones(self.ny)
@@ -294,6 +295,8 @@ class SymbolicSys(ODESys):
             autonomous_exprs=_is_autonomous(self.indep, self.exprs),
             **kwargs)
 
+        if self.sparse:
+            self.nnz = len(self._rowvals)
         self.linear_invariants = linear_invariants
         self.nonlinear_invariants = nonlinear_invariants
         self.linear_invariant_names = linear_invariant_names or None
@@ -630,11 +633,13 @@ class SymbolicSys(ODESys):
     def get_jac(self):
         """ Derives the jacobian from ``self.exprs`` and ``self.dep``. """
         if self._jac is True:
-            if self.band is None:
+            if self.sparse is True:
+                self._jac, self._colptrs, self._rowvals = self.be.sparse_jacobian_csc(self.exprs, self.dep)
+            elif self.band is not None: #Banded
+                self._jac = self.be.banded_jacobian(self.exprs, self.dep, *self.band)
+            else:
                 f = self.be.Matrix(1, self.ny, self.exprs)
                 self._jac = f.jacobian(self.be.Matrix(1, self.ny, self.dep))
-            else:  # Banded
-                self._jac = self.be.banded_jacobian(self.exprs, self.dep, *self.band)
         elif self._jac is False:
             return False
 
@@ -704,7 +709,17 @@ class SymbolicSys(ODESys):
         j_exprs = self.get_jac()
         if j_exprs is False:
             return None
-        return self._callback_factory(j_exprs)
+        cb = self._callback_factory(j_exprs)
+        if self.sparse:
+            from scipy.sparse import csc_matrix
+
+            def sparse_cb(x, y, p=()):
+                data = cb(x, y, p).flatten()
+                return csc_matrix((data, self._rowvals, self._colptrs))
+
+            return sparse_cb
+        else:
+            return cb
 
     def get_dfdx_callback(self):
         """ Generate a callback for evaluating derivative of ``self.exprs`` """

--- a/pyodesys/symbolic.py
+++ b/pyodesys/symbolic.py
@@ -278,7 +278,7 @@ class SymbolicSys(ODESys):
         if _param_names is True:
             kwargs['param_names'] = [p.name for p in self.params]
 
-        self.sparse = sparse # needed by get_j_ty_callback
+        self.sparse = sparse  # needed by get_j_ty_callback
         self.band = kwargs.get('band', None)  # needed by get_j_ty_callback
         # bounds needed by get_f_ty_callback:
         self.lower_bounds = None if lower_bounds is None else np.array(lower_bounds)*np.ones(self.ny)
@@ -635,7 +635,7 @@ class SymbolicSys(ODESys):
         if self._jac is True:
             if self.sparse is True:
                 self._jac, self._colptrs, self._rowvals = self.be.sparse_jacobian_csc(self.exprs, self.dep)
-            elif self.band is not None: #Banded
+            elif self.band is not None:  # Banded
                 self._jac = self.be.banded_jacobian(self.exprs, self.dep, *self.band)
             else:
                 f = self.be.Matrix(1, self.ny, self.exprs)

--- a/pyodesys/tests/test_symbolic.py
+++ b/pyodesys/tests/test_symbolic.py
@@ -21,7 +21,7 @@ else:
 from .. import ODESys
 from ..core import integrate_auto_switch, chained_parameter_variation
 from ..symbolic import SymbolicSys, ScaledSys, symmetricsys, PartiallySolvedSystem, get_logexp, _group_invariants
-from ..util import requires, pycvodes_double
+from ..util import requires, pycvodes_double, pycvodes_klu
 from .bateman import bateman_full  # analytic, never mind the details
 from .test_core import vdp_f
 from . import _cetsa
@@ -134,6 +134,18 @@ def test_SymbolicSys__jacobian_singular():
     k = (4, 3)
     odesys = SymbolicSys.from_callback(decay_dydt_factory(k), len(k)+1)
     assert odesys.jacobian_singular()
+
+
+@requires('sym', 'pycvodes')
+@pycvodes_klu
+def test_SymbolicSys_jacobian_sparse():
+    k = (4, 3)
+    y0 = (5, 4, 2)
+    odesys = SymbolicSys.from_callback(decay_dydt_factory(k), len(k) + 1, sparse=True)
+    xout, yout, info = odesys.integrate([0, 2], y0, integrator='cvode', linear_solver='klu',
+                                        atol=1e-12, rtol=1e-12, nsteps=1000)
+    ref = np.array(bateman_full(y0, k+(0,), xout - xout[0], exp=np.exp)).T
+    assert np.allclose(yout, ref, rtol=1e-10, atol=1e-10)
 
 
 @requires('sym', 'pycvodes')

--- a/pyodesys/util.py
+++ b/pyodesys/util.py
@@ -244,10 +244,13 @@ def pycvodes_double(cb):
     return pytest.mark.skipif(prec != "double", reason=r)(cb)
 
 
-try:
-    from pycvodes.tests.test_cvodes_numpy import requires_klu as pycvodes_klu
-except (ModuleNotFoundError, ImportError):
-    pycvodes_klu = pytest.skip("Sparse jacobian tests require pycvodes and sundials with KLU enabled.")
+def pycvodes_klu(cb):
+    try:
+        from pycvodes._config import env
+        no_klu = env['NO_KLU'] == '1'
+    except (ModuleNotFoundError, ImportError):
+        no_klu = True
+    return pytest.mark.skipif(no_klu, reason="Sparse jacobian tests require pycvodes and sundials with KLU enabled.")(cb)
 
 
 class MissingImport(object):

--- a/pyodesys/util.py
+++ b/pyodesys/util.py
@@ -245,6 +245,12 @@ def pycvodes_double(cb):
     return pytest.mark.skipif(prec != "double", reason=r)(cb)
 
 
+try:
+    from pycvodes.tests.test_cvodes_numpy import requires_klu as pycvodes_klu
+except (ModuleNotFoundError, ImportError):
+    pycvodes_klu = pytest.skip("Sparse jacobian tests require pycvodes and sundials with KLU enabled.")
+
+
 class MissingImport(object):
 
     def __init__(self, modname, exc):

--- a/pyodesys/util.py
+++ b/pyodesys/util.py
@@ -250,7 +250,8 @@ def pycvodes_klu(cb):
         no_klu = env['NO_KLU'] == '1'
     except (ModuleNotFoundError, ImportError):
         no_klu = True
-    return pytest.mark.skipif(no_klu, reason="Sparse jacobian tests require pycvodes and sundials with KLU enabled.")(cb)
+    return pytest.mark.skipif(no_klu,
+                              reason="Sparse jacobian tests require pycvodes and sundials with KLU enabled.")(cb)
 
 
 class MissingImport(object):

--- a/pyodesys/util.py
+++ b/pyodesys/util.py
@@ -9,6 +9,7 @@ import operator
 from pkg_resources import parse_requirements, parse_version
 
 import numpy as np
+import pytest
 
 
 def stack_1d_on_left(x, y):
@@ -225,7 +226,6 @@ class requires(object):
                             self.incomp.append(str(req))
 
     def __call__(self, cb):
-        import pytest
         r = 'Unfulfilled requirements.'
         if self.missing:
             r += " Missing modules: %s." % ', '.join(self.missing)
@@ -235,7 +235,6 @@ class requires(object):
 
 
 def pycvodes_double(cb):
-    import pytest
     try:
         from pycvodes._config import env
         prec = env.get('SUNDIALS_PRECISION', 'double')

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup_kwargs = dict(
     license=license,
     packages=[pkg_name] + submodules + tests,
     include_package_data=True,
-    install_requires=['numpy>=1.8.0', 'pytest>=2.9.2', 'scipy>=0.19.1', 'sym>=0.3.3',
+    install_requires=['numpy>=1.8.0', 'pytest>=2.9.2', 'scipy>=0.19.1', 'sym>=0.3.4',
                       'sympy>=1.1.1,!=1.2', 'matplotlib>=2.0.2', 'jupyter'],
     extras_require=extras_req
 )


### PR DESCRIPTION
Addresses #89.

From a design standpoint, I was conflicted about whether to:

1. implement the sparse jacobian as a separate callback/set of expressions (cf. `jtimes`, `dfdx`, etc.)
2. Overload the behavior of the jacobian callback/symbolic expressions

I opted for the latter, mirroring how `pycvodes` currently accommodates dense vs. banded vs. sparse jacobians. The drawback is that a given SymbolicSys/ODESys is implicitly tied to certain integrators/linear solvers at time of instantiation, rather than existing as an independent construct usable with an arbitrary integrator...